### PR TITLE
ci: fix venv regression

### DIFF
--- a/.github/workflows/release-package-venv.yaml
+++ b/.github/workflows/release-package-venv.yaml
@@ -12,6 +12,9 @@ jobs:
         python_version: ['3.11']
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
       - name: Build venv package
         uses: minvws/action-python-venv-package@v1
         with:


### PR DESCRIPTION
In #74 I forgot to add a checkout step to the workflow, which is necessary since the standalone action-python-venv-package's `checkout_repository` now defaults to `"false"`.
