### PR TITLE
feat: control background schedule from application config

### DIFF
--- a/app.conf.example
+++ b/app.conf.example
@@ -7,6 +7,8 @@ provider_id=4af95a5f-3663-4832-b080-8ba1548e78f5
 [scheduler]
 # the amount of seconds the update will run in the background
 scheduled_delay=5
+# background updates automatically start on bootstrap
+automatic_background_update = True
 
 [metadata_api]
 # The base URLs of FHIR stores (metadata registers)

--- a/app/application.py
+++ b/app/application.py
@@ -54,10 +54,12 @@ def create_fastapi_app() -> FastAPI:
 
 
 def application_init() -> None:
+    config = get_config()
     setup_container()
     setup_logging()
-    scheduler = get_scheduler()
-    scheduler.start()
+    if config.scheduler.automatic_background_update:
+        scheduler = get_scheduler()
+        scheduler.start()
 
 
 def setup_logging() -> None:

--- a/app/config.py
+++ b/app/config.py
@@ -25,6 +25,7 @@ class ConfigApp(BaseModel):
 
 class ConfigScheduler(BaseModel):
     scheduled_delay: int = Field(default=5)
+    automatic_background_update: bool = Field(default=True)
 
 
 class ConfigMetadataApi(BaseModel):
@@ -114,5 +115,4 @@ def get_config(path: str | None = None) -> Config:
     ini_data = read_ini_file(path)
 
     _CONFIG = Config(**ini_data)
-
     return _CONFIG


### PR DESCRIPTION
- added the ability to turn on/off automatic background update from application config

part of [issue 68](https://github.com/minvws/gfmodules-nationale-verwijsindex-registratie-service-private/issues/68)