### PR TITLE
Register NVI-RS at PRS after container init

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -7,7 +7,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from app.config import get_config
-from app.container import get_scheduler, setup_container
+from app.container import get_prs_registration_service, get_scheduler, setup_container
 from app.exceptions.fhir_exception import (
     OperationOutcome,
     OperationOutcomeDetail,
@@ -58,6 +58,8 @@ def application_init() -> None:
     config = get_config()
     setup_container()
     setup_logging()
+    register_service = get_prs_registration_service()
+    register_service.register_nvi_rs_at_prs()
     if config.scheduler.automatic_background_update:
         scheduler = get_scheduler()
         scheduler.start()

--- a/app/container.py
+++ b/app/container.py
@@ -11,6 +11,7 @@ from app.services.OtvService.interface import OtvService
 from app.services.pseudonym import PseudonymService
 from app.services.registration.bundle import BundleRegistartionService
 from app.services.registration.referrals import ReferralRegistrationService
+from app.services.registration_service import PrsRegistrationService
 from app.services.synchronization.domain_map import DomainsMapService
 from app.services.synchronization.scheduler import Scheduler
 from app.services.synchronization.synchronizer import Synchronizer
@@ -73,6 +74,9 @@ def container_config(binder: inject.Binder) -> None:
 
     domain_map_service = DomainsMapService(data_domains=config.app.data_domains)
 
+    prs_registration_service = PrsRegistrationService(conf=config.pseudonym_api, ura_number=ura_number)
+    binder.bind(PrsRegistrationService, prs_registration_service)
+
     synchronizer = Synchronizer(
         registration_service=referral_registration_service,
         metadata_api=metadata_service,
@@ -90,6 +94,8 @@ def container_config(binder: inject.Binder) -> None:
 def get_authorization_check_service() -> AuthorizationCheckService:
     return inject.instance(AuthorizationCheckService)
 
+def get_prs_registration_service() -> PrsRegistrationService:
+    return inject.instance(PrsRegistrationService)
 
 def get_otv_service() -> OtvService:
     instance = inject.instance(OtvService)

--- a/app/services/authorization_check_service.py
+++ b/app/services/authorization_check_service.py
@@ -52,7 +52,7 @@ class AuthorizationCheckService:
         # Create OTV reversible pseudonym
         req = self._pseudonym_service.make_reversible_request_dto(
             bsn=bsn,
-            recipient_organization_ura=permission_request.client_ura_number,
+            recipient_organization_ura=self._otv_ura_number,
         )
         reversible_pseudonym = self._pseudonym_service.request_reversible(req)
 

--- a/app/services/pseudonym.py
+++ b/app/services/pseudonym.py
@@ -86,7 +86,7 @@ class PseudonymService:
         return ReversiblePseudonymRequest(
             personal_id=f"NL:BSN:{bsn.value}",
             recipient_organization="ura:" + recipient_organization_ura.value,
-            recipient_scope="otv",
+            recipient_scope="online-toestemmingsvoorziening-stub",
             pseudonym_type="reversible",
         )
 

--- a/app/services/registration_service.py
+++ b/app/services/registration_service.py
@@ -1,0 +1,81 @@
+import logging
+
+import requests
+
+from app.config import ConfigPseudonymApi
+from app.models.ura_number import UraNumber
+
+logger = logging.getLogger(__name__)
+
+
+class PseudonymError(Exception):
+    pass
+
+
+class PrsRegistrationService:
+    def __init__(self, conf: ConfigPseudonymApi, ura_number: UraNumber) -> None:
+        self.conf = conf
+        self._ura_number = ura_number
+
+    def register_nvi_rs_at_prs(self) -> None:
+        """
+        Register the nvi_rs organization and certificate at the PRS.
+        """
+        logger.info("Registering nvi_rs at PRS")
+
+        if self.conf.mock:
+            logger.info("Mock mode enabled, skipping registration at PRS")
+            return
+
+        try:
+            self.__register_organization()
+            self.__register_certificate()
+        except Exception as e:
+            logger.error(f"Failed to register nvi_rs at PRS: {e}")
+            raise PseudonymError("Failed to register nvi_rs at PRS") from e
+
+    def __register_organization(self) -> None:
+        """
+        Register the nvi_rs organization at the PRS.
+        """
+        try:
+            request = requests.post(
+                url=f"{self.conf.endpoint}/orgs",
+                json={
+                    "ura": str(self._ura_number),
+                    "name": "nationale-verwijsindex-registratie-service",
+                    "max_key_usage": "rp",
+                },
+                timeout=self.conf.timeout,
+                cert=(self.conf.mtls_cert, self.conf.mtls_key),  # type: ignore
+                verify=self.conf.mtls_ca,
+            )
+            if request.status_code == 409:
+                logger.info("Organization already registered at PRS")
+                return
+            request.raise_for_status()
+        except requests.RequestException as e:
+            logger.error(f"Failed to register organization: {e}")
+            raise PseudonymError("Failed to register organization")
+
+    def __register_certificate(self) -> None:
+        """
+        Register the nvi_rs certificate at the PRS.
+        """
+        try:
+            request = requests.post(
+                url=f"{self.conf.endpoint}/register/certificate",
+                json={
+                    "scope": ["nationale-verwijsindex-registratie-service"],
+                },
+                timeout=self.conf.timeout,
+                cert=(self.conf.mtls_cert, self.conf.mtls_key),  # type: ignore
+                verify=self.conf.mtls_ca,
+            )
+            if request.status_code == 409:
+                logger.info("Certificate already registered at PRS")
+                return
+            request.raise_for_status()
+        except requests.RequestException as e:
+            logger.error(f"Failed to register certificate: {e}")
+            raise PseudonymError("Failed to register certificate")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from fhir.resources.R4B.bundle import Bundle
 from fhir.resources.R4B.imagingstudy import ImagingStudy
 from fhir.resources.R4B.patient import Patient
 
+from app.config import ConfigPseudonymApi
 from app.data import BSN_SYSTEM
 from app.models.metadata.params import MetadataResourceParams
 from app.models.pseudonym import Pseudonym
@@ -23,6 +24,7 @@ from app.services.OtvService.otv_stub_service import OtvStubService
 from app.services.pseudonym import PseudonymService
 from app.services.registration.bundle import BundleRegistartionService
 from app.services.registration.referrals import ReferralRegistrationService
+from app.services.registration_service import PrsRegistrationService
 from app.services.synchronization.domain_map import DomainsMapService
 from app.services.synchronization.synchronizer import Synchronizer
 from tests.services.api_services.test_api_service import MockHttpService
@@ -36,6 +38,34 @@ def http_service(mock_url: str) -> HttpService:
         mtls_cert=None,
         mtls_key=None,
         mtls_ca=None,
+    )
+
+
+@pytest.fixture
+def config_pseudonym_api() -> ConfigPseudonymApi:
+    return ConfigPseudonymApi(
+        endpoint="https://example.com",
+        timeout=5,
+        mtls_cert="/path/to/cert.pem",
+        mtls_key="/path/to/key.pem",
+        mtls_ca="/path/to/ca.pem",
+        mock=False,
+    )
+
+
+@pytest.fixture
+def ura_number() -> UraNumber:
+    return UraNumber("12345678")
+
+
+@pytest.fixture()
+def prs_registration_service(
+    config_pseudonym_api: ConfigPseudonymApi,
+    ura_number: UraNumber,
+) -> PrsRegistrationService:
+    return PrsRegistrationService(
+        conf=config_pseudonym_api,
+        ura_number=ura_number,
     )
 
 

--- a/tests/services/test_prs_registration_service.py
+++ b/tests/services/test_prs_registration_service.py
@@ -1,0 +1,98 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from app.config import ConfigPseudonymApi
+from app.models.ura_number import UraNumber
+from app.services.registration_service import PrsRegistrationService, PseudonymError
+
+
+def test_register_nvi_rs_at_prs_success(
+    prs_registration_service: PrsRegistrationService,
+    mocker: MockerFixture,
+) -> None:
+    post_mock = mocker.patch("requests.post")
+    post_mock.return_value.status_code = 201
+
+    prs_registration_service.register_nvi_rs_at_prs()
+
+    assert post_mock.call_count == 2
+    org_call = post_mock.call_args_list[0]
+    cert_call = post_mock.call_args_list[1]
+
+    assert org_call[1]["url"].endswith("/orgs")
+    assert cert_call[1]["url"].endswith("/register/certificate")
+
+    assert org_call[1]["json"]["ura"] == "12345678"
+    assert org_call[1]["json"]["name"] == "nationale-verwijsindex-registratie-service"
+    assert org_call[1]["json"]["max_key_usage"] == "rp"
+
+    assert cert_call[1]["json"]["scope"] == ["nationale-verwijsindex-registratie-service"]
+
+
+def test_register_nvi_rs_at_prs_org_already_registered(
+    prs_registration_service: PrsRegistrationService,
+    mocker: MockerFixture,
+) -> None:
+    post_mock = mocker.patch("requests.post")
+    logging_mock = mocker.patch("app.services.registration_service.logger")
+    post_mock.side_effect = [
+        mocker.Mock(status_code=409),  # Organization already registered
+        mocker.Mock(status_code=201),  # Certificate registration success
+    ]
+
+    prs_registration_service.register_nvi_rs_at_prs()
+
+    assert post_mock.call_count == 2
+    logging_mock.info.assert_any_call("Organization already registered at PRS")
+
+
+def test_register_nvi_rs_at_prs_cert_already_registered(
+    prs_registration_service: PrsRegistrationService,
+    mocker: MockerFixture,
+) -> None:
+    post_mock = mocker.patch("requests.post")
+    logging_mock = mocker.patch("app.services.registration_service.logger")
+    post_mock.side_effect = [
+        mocker.Mock(status_code=201),  # Organization registration success
+        mocker.Mock(status_code=409),  # Certificate already registered
+    ]
+
+    prs_registration_service.register_nvi_rs_at_prs()
+
+    assert post_mock.call_count == 2
+    logging_mock.info.assert_any_call("Certificate already registered at PRS")
+
+
+def test_register_nvi_rs_at_prs_failure(
+    prs_registration_service: PrsRegistrationService,
+    mocker: MockerFixture,
+) -> None:
+    post_mock = mocker.patch("requests.post")
+    post_mock.side_effect = Exception("Network error")
+
+    with pytest.raises(Exception) as excinfo:
+        prs_registration_service.register_nvi_rs_at_prs()
+
+    assert "Failed to register nvi_rs at PRS" in str(excinfo.value)
+    assert post_mock.call_count == 1
+    assert isinstance(excinfo.value, PseudonymError)
+
+
+def test_register_nvi_rs_at_prs_mock_mode(
+    config_pseudonym_api: ConfigPseudonymApi,
+    ura_number: UraNumber,
+    mocker: MockerFixture,
+) -> None:
+    config_pseudonym_api.mock = True
+    prs_registration_service = PrsRegistrationService(
+        conf=config_pseudonym_api,
+        ura_number=ura_number,
+    )
+
+    post_mock = mocker.patch("requests.post")
+    logging_mock = mocker.patch("app.services.registration_service.logger")
+
+    prs_registration_service.register_nvi_rs_at_prs()
+
+    post_mock.assert_not_called()
+    logging_mock.info.assert_any_call("Mock mode enabled, skipping registration at PRS")


### PR DESCRIPTION
Extra for: https://github.com/minvws/gfmodules-coordination-private/issues/615
Register NVI-RS at PRS after container init.
Fixed: `make_reversible_request_dto` had wrong `recipient_organization_ura`.
Updated scope from "otv" to "online-toestemmingsvoorziening-stub" to stay above the 5 characters