### PR TITLE
Ensure encryption key is set when creating configuration file

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -3,12 +3,16 @@
 set -e
 
 APP_PATH="${FASTAPI_CONFIG_PATH:-app.conf}"
+APP_CONFIG_TEMPLATE_PATH="${APP_CONFIG_TEMPLATE_PATH:-app.conf.example}"
 
 echo "➡️ Creating the configuration file"
 if [ -e "$APP_PATH" ]; then
     echo "⚠️ Configuration file already exists. Skipping."
 else
-    cp app.conf.example $APP_PATH
+    cp "$APP_CONFIG_TEMPLATE_PATH" "$APP_PATH"
+
+    ENCRYPTION_KEY="$(openssl rand -base64 32)"
+    sed -i "s|^\(encryption_key=\).*|\1$ENCRYPTION_KEY|" "$APP_PATH"
 fi
 
 echo "Start main process"


### PR DESCRIPTION
Automattically creates encryptionkey. 

Handy, so you dont have to store a key in for example app.conf.coordination.

```
[lmr]
encryption_key=
```