### PR TITLE
Set verify option from request to True

### DIFF
--- a/app/services/api/http_service.py
+++ b/app/services/api/http_service.py
@@ -45,7 +45,7 @@ class HttpService(ABC):
     ) -> Response:
         try:
             cert = (self._mtls_cert, self._mtls_key) if self._mtls_cert and self._mtls_key else None
-            verify = self._mtls_ca if self._mtls_ca else True
+            verify = True
             response = request(
                 method=method,
                 url=f"{self._endpoint}/{sub_route}" if sub_route else self._endpoint,

--- a/tests/services/api_services/test_api_service.py
+++ b/tests/services/api_services/test_api_service.py
@@ -157,7 +157,7 @@ def test_do_request_should_use_mtls_cert_when_enabled(
     mock_request.assert_called_once()
     call_kwargs = mock_request.call_args[1]
     assert call_kwargs["cert"] == ("test.crt", "test.key")
-    assert call_kwargs["verify"] == "test.ca"
+    assert call_kwargs["verify"] == True
 
 
 @patch(PATCHED_MODULE)
@@ -182,7 +182,7 @@ def test_do_request_should_use_ca_file_for_verification_when_provided(
     mock_request.assert_called_once()
     call_kwargs = mock_request.call_args[1]
     assert call_kwargs["cert"] == ("test.crt", "test.key")
-    assert call_kwargs["verify"] == "ca.crt"
+    assert call_kwargs["verify"] == True
 
 
 @patch(PATCHED_MODULE)


### PR DESCRIPTION
This is due the fact that this option has no effect on the actual mtls certificate presented. We present our mtls_cert and it will be accepted by the server or not (it will check the chain).

The verify is here for the main SSL certificate from the server, which in our case is normally a letsencrypt certificate. We need to validate that and not use our own ca for that unless we use self-signed certificates on this.