### PR TITLE
Handle NVI query Endpoint bundle responses

### DIFF
--- a/app/services/registration/referrals.py
+++ b/app/services/registration/referrals.py
@@ -49,7 +49,7 @@ class ReferralRegistrationService:
             )
         )
 
-        referral = self.nvi_service.get_referrals(
+        referral_registered = self.nvi_service.is_referral_registered(
             ReferralQuery(
                 oprf_jwe=pseudonym,
                 blind_factor=blind_factor,
@@ -58,7 +58,7 @@ class ReferralRegistrationService:
             )
         )
 
-        if referral:
+        if referral_registered:
             logger.info(f"referral for {pseudonym.jwe} and data domain {data_domain} already registered")
             return None
 

--- a/tests/services/registration/test_referrals.py
+++ b/tests/services/registration/test_referrals.py
@@ -11,7 +11,7 @@ PATCHED_PSEUDONYM = "app.services.registration.referrals.PseudonymService.submit
 
 
 @patch(f"{PATCHED_NVI}.submit")
-@patch(f"{PATCHED_NVI}.get_referrals")
+@patch(f"{PATCHED_NVI}.is_referral_registered")
 @patch(PATCHED_PSEUDONYM)
 def test_register_should_succeed(
     pseudonym_response: MagicMock,
@@ -31,7 +31,7 @@ def test_register_should_succeed(
     assert mock_referral == actual
 
 
-@patch(f"{PATCHED_NVI}.get_referrals")
+@patch(f"{PATCHED_NVI}.is_referral_registered")
 @patch(PATCHED_PSEUDONYM)
 def test_register_should_return_none_if_referral_exists(
     pseudonym_response: MagicMock,

--- a/tests/services/synchronization/test_synchronizer.py
+++ b/tests/services/synchronization/test_synchronizer.py
@@ -100,7 +100,7 @@ def test_get_allowed_domains(
 @patch(f"{PATCHED_METADATA_API}.get_update_scheme")
 @patch(f"{PATCHED_PSEUDONYM_API}.submit")
 @patch(f"{PATCHED_NVI_API}.submit")
-@patch(f"{PATCHED_NVI_API}.get_referrals")
+@patch(f"{PATCHED_NVI_API}.is_referral_registered")
 @patch(PATCHED_SYNCHRONIZE_HEALTH)
 def test_synchronize_should_succeed_when_there_is_data_from_metadata(
     mock_healthcheck: MagicMock,
@@ -138,7 +138,7 @@ def test_synchronize_should_succeed_when_there_is_data_from_metadata(
 @patch(f"{PATCHED_METADATA_API}.get_update_scheme")
 @patch(f"{PATCHED_PSEUDONYM_API}.submit")
 @patch(f"{PATCHED_NVI_API}.submit")
-@patch(f"{PATCHED_NVI_API}.get_referrals")
+@patch(f"{PATCHED_NVI_API}.is_referral_registered")
 @patch(PATCHED_SYNCHRONIZE_HEALTH)
 def test_synchronize_should_succeed_and_update_timestamp_on_domain_entry_when_there_is_update_from_metadata(
     mock_healthcheck: MagicMock,
@@ -194,7 +194,7 @@ def test_synchronize_should_succeed_and_update_timestamp_on_domain_entry_when_th
 @patch(f"{PATCHED_METADATA_API}.get_update_scheme")
 @patch(f"{PATCHED_PSEUDONYM_API}.submit")
 @patch(f"{PATCHED_NVI_API}.submit")
-@patch(f"{PATCHED_NVI_API}.get_referrals")
+@patch(f"{PATCHED_NVI_API}.is_referral_registered")
 @patch(PATCHED_SYNCHRONIZE_HEALTH)
 def test_synchronize_should_succeed_and_return_only_new_domain_entries_when_no_patients_are_updated_from_metadata(
     mock_healthcheck: MagicMock,
@@ -228,7 +228,7 @@ def test_synchronize_should_succeed_and_return_only_new_domain_entries_when_no_p
 @patch(f"{PATCHED_METADATA_API}.get_update_scheme")
 @patch(f"{PATCHED_PSEUDONYM_API}.submit")
 @patch(f"{PATCHED_NVI_API}.submit")
-@patch(f"{PATCHED_NVI_API}.get_referrals")
+@patch(f"{PATCHED_NVI_API}.is_referral_registered")
 @patch(PATCHED_SYNCHRONIZE_HEALTH)
 def test_syncrhonize_should_succeed_and_update_timestamp_when_referral_exists(
     mock_healthcheck: MagicMock,
@@ -266,7 +266,7 @@ def test_syncrhonize_should_succeed_and_update_timestamp_when_referral_exists(
 @patch(f"{PATCHED_METADATA_API}.get_update_scheme")
 @patch(f"{PATCHED_PSEUDONYM_API}.submit")
 @patch(f"{PATCHED_NVI_API}.submit")
-@patch(f"{PATCHED_NVI_API}.get_referrals")
+@patch(f"{PATCHED_NVI_API}.is_referral_registered")
 @patch(PATCHED_SYNCHRONIZE_HEALTH)
 def test_synchronize_should_fail_when_nvi_is_unreachable(
     mock_healthcheck: MagicMock,
@@ -301,7 +301,7 @@ def test_synchronize_should_fail_when_nvi_is_unreachable(
 @patch(f"{PATCHED_METADATA_API}.get_update_scheme")
 @patch(f"{PATCHED_PSEUDONYM_API}.submit")
 @patch(f"{PATCHED_NVI_API}.submit")
-@patch(f"{PATCHED_NVI_API}.get_referrals")
+@patch(f"{PATCHED_NVI_API}.is_referral_registered")
 @patch(PATCHED_SYNCHRONIZE_HEALTH)
 def test_synchronize_should_fail_when_pseudonym_api_is_unreachable(
     mock_healthcheck: MagicMock,
@@ -333,7 +333,7 @@ def test_synchronize_should_fail_when_pseudonym_api_is_unreachable(
 @patch(f"{PATCHED_METADATA_API}.get_update_scheme")
 @patch(f"{PATCHED_PSEUDONYM_API}.submit")
 @patch(f"{PATCHED_NVI_API}.submit")
-@patch(f"{PATCHED_NVI_API}.get_referrals")
+@patch(f"{PATCHED_NVI_API}.is_referral_registered")
 @patch(PATCHED_SYNCHRONIZE_HEALTH)
 def test_syncrhonize_should_fail_when_metadata_is_unreachable(
     mock_healthcheck: MagicMock,


### PR DESCRIPTION
According to the NVI Technical Design, the NVI query Endpoint responds with a bundle. 

This PR updates the query check so it can handle bundle responses.
Due to what this app needs, the response isn't entirely parsed to a DTO but only checks for entries instead.
  - If entries present: don't register again, else register.