### PR TITLE
Pipeline image scanning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,12 +153,6 @@ jobs:
       steps:
         - name: Checkout repository
           uses: actions/checkout@v6
-        - name: Check Dockerfile changes
-          id: dockerfile-changed
-          uses: tj-actions/changed-files@e0021407031f5be11a464abee9a0776171c79891 # v46
-          with:
-            files: |
-              docker/Dockerfile
         - name: Check image-related file changes
           id: image-files-changed
           uses: tj-actions/changed-files@e0021407031f5be11a464abee9a0776171c79891 # v46


### PR DESCRIPTION
First setup of trivy pipeline image scanning:
https://github.com/aquasecurity/trivy-action

Runs scan on image if Dockerfile/poetry-dependencies changed or on merge to main. 

Issue: https://github.com/minvws/gfmodules-coordination-private/issues/748